### PR TITLE
feat: Add RESTful POST endpoint for AI chat using langchain4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,13 @@
             <version>0.36.0</version>
         </dependency>
 
+        <!-- langchain4j-ollama-spring-boot-starter -->
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-ollama-spring-boot-starter</artifactId>
+            <version>0.30.0</version>
+        </dependency>
+
 
 <!--&lt;!&ndash;        qwen&ndash;&gt;-->
 <!--        &lt;!&ndash; https://mvnrepository.com/artifact/dev.langchain4j/langchain4j-community-dashscope-spring-boot-starter &ndash;&gt;-->

--- a/src/main/java/robin/discordbot/controller/ApiController.java
+++ b/src/main/java/robin/discordbot/controller/ApiController.java
@@ -4,6 +4,7 @@ import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.dashscope.QwenChatModel;
 import io.github.cdimascio.dotenv.Dotenv;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.annotation.Resource;
@@ -12,18 +13,24 @@ import robin.discordbot.pojo.entity.Result;
 import robin.discordbot.pojo.entity.User;
 import robin.discordbot.pojo.entity.aiEntity.AiMessageFormat;
 import robin.discordbot.service.ApiService;
+import robin.discordbot.service.LangChain4jService;
 import robin.discordbot.utils.entityTest;
 
 @RestController
 @RequestMapping("/api")
 public class ApiController {
 
-    /**
-     * Apifox Helper Dify controller
-     */
-    @Resource
-    private ApiService haloService;
+    private final ApiService haloService;
+    private final LangChain4jService langChain4jService;
+
     public static Dotenv dotenv = Dotenv.load();
+
+    @Autowired
+    public ApiController(ApiService haloService, LangChain4jService langChain4jService) {
+        this.haloService = haloService;
+        this.langChain4jService = langChain4jService;
+    }
+
     public static String getQwenToken() {
         return dotenv.get("qwen");
     }
@@ -53,5 +60,10 @@ public class ApiController {
     public String article(@RequestParam String article){
         System.out.println(article);
         return "success";
+    }
+
+    @PostMapping("/chat")
+    public String chatWithBot(@RequestBody String message) {
+        return langChain4jService.chat(message);
     }
 }

--- a/src/main/java/robin/discordbot/service/LangChain4jService.java
+++ b/src/main/java/robin/discordbot/service/LangChain4jService.java
@@ -1,5 +1,6 @@
 package robin.discordbot.service;
 
+import dev.langchain4j.model.chat.ChatLanguageModel;
 import robin.discordbot.pojo.entity.aiEntity.AiMessageFormat;
 import robin.discordbot.pojo.entity.aiEntity.aiSearchFinalEntity;
 
@@ -22,5 +23,5 @@ public interface LangChain4jService {
 
     aiSearchFinalEntity aisearchNSFW(String id, AiMessageFormat aiMessageFormat);
 
-
+    String chat(String message);
 }

--- a/src/main/java/robin/discordbot/service/impl/LangChain4jServiceImpl.java
+++ b/src/main/java/robin/discordbot/service/impl/LangChain4jServiceImpl.java
@@ -6,6 +6,7 @@ import cn.hutool.http.HttpUtil;
 import cn.hutool.json.JSONObject;
 import cn.hutool.json.JSONUtil;
 import dev.langchain4j.data.image.Image;
+import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.image.ImageModel;
 import dev.langchain4j.model.openai.OpenAiImageModel;
 import dev.langchain4j.model.output.Response;
@@ -48,6 +49,9 @@ public class LangChain4jServiceImpl implements LangChain4jService {
     private Langchain4j.AiAssistantGeminiTranslateCN2EN geminiTranslateCN2EN;
 //    @Resource
 //    private Langchain4j.AiAssistantPlayground aiPlayground;
+
+    @Autowired
+    private ChatLanguageModel chatLanguageModel;
 
     private final Dotenv dotenv = Dotenv.load();
 
@@ -226,5 +230,8 @@ public class LangChain4jServiceImpl implements LangChain4jService {
         return null;
     }
 
-
+    @Override
+    public String chat(String message) {
+        return chatLanguageModel.generate(message);
+    }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,6 +32,15 @@ openai:
   api:
     url: https://api.openai.com/v1/chat/completions
 
+langchain4j:
+  ollama:
+    chat-model:
+      base-url: http://localhost:11434  # Replace with your Ollama base URL if different
+      model-name: mistral  # Replace with your desired model name
+      temperature: 0.7
+      timeout: 60s
+      max-retries: 3
+
 
 
 

--- a/src/test/java/robin/discordbot/controller/ApiControllerTest.java
+++ b/src/test/java/robin/discordbot/controller/ApiControllerTest.java
@@ -1,0 +1,45 @@
+package robin.discordbot.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import robin.discordbot.service.LangChain4jService;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ApiController.class)
+public class ApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LangChain4jService langChain4jService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void testChatWithBot() throws Exception {
+        String userMessage = "Hello, AI!";
+        String aiResponse = "Hello, User!";
+
+        when(langChain4jService.chat(userMessage)).thenReturn(aiResponse);
+
+        mockMvc.perform(post("/api/chat")
+                        .contentType(MediaType.APPLICATION_JSON) // Assuming the controller expects JSON
+                        .content(userMessage)) // Sending raw string as content
+                .andExpect(status().isOk())
+                .andExpect(content().string(aiResponse));
+
+        verify(langChain4jService).chat(userMessage);
+    }
+}

--- a/src/test/java/robin/discordbot/service/impl/LangChain4jServiceImplTest.java
+++ b/src/test/java/robin/discordbot/service/impl/LangChain4jServiceImplTest.java
@@ -1,0 +1,46 @@
+package robin.discordbot.service.impl;
+
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import robin.discordbot.service.LangChain4jService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class LangChain4jServiceImplTest {
+
+    @Mock
+    private ChatLanguageModel chatLanguageModel;
+
+    @InjectMocks
+    private LangChain4jServiceImpl langChain4jService;
+
+    @BeforeEach
+    public void setUp() {
+        // Initialize mocks created with @Mock and inject them into @InjectMocks fields
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testChat() {
+        String userMessage = "Hello, LangChain4j!";
+        String expectedResponse = "Hello, User!";
+
+        // Mock the behavior of chatLanguageModel.generate()
+        when(chatLanguageModel.generate(userMessage)).thenReturn(expectedResponse);
+
+        // Call the method to be tested
+        String actualResponse = langChain4jService.chat(userMessage);
+
+        // Verify that chatLanguageModel.generate() was called with the correct message
+        verify(chatLanguageModel).generate(userMessage);
+
+        // Verify that the method returned the expected response
+        assertEquals(expectedResponse, actualResponse);
+    }
+}


### PR DESCRIPTION
This commit introduces a new RESTful POST endpoint `/api/chat` that allows you to interact with an AI model via langchain4j.

The changes include:
- Added `langchain4j-ollama-spring-boot-starter` dependency for Ollama integration.
- Implemented the `chat` method in `LangChain4jServiceImpl` to generate AI responses using `ChatLanguageModel`.
- Added a new POST endpoint `/api/chat` in `ApiController` to handle chat requests.
- Configured Ollama settings (base URL, model name) in `application.yaml`.
- Added unit tests for `ApiController` and `LangChain4jServiceImpl` to ensure the functionality of the new feature.